### PR TITLE
Fix no-unused-vars inconsistency between JS and TS files

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -5,6 +5,7 @@ import { combine } from '#utils';
 import { config as getterReturn } from './rules/getter-return.js';
 import { config as importSorting } from './rules/import-sorting.js';
 import { config as noConsole } from './rules/no-console.js';
+import { config as noUnusedVars } from './rules/no-unused-vars.js';
 import { config as allowVar } from './rules/no-var.js';
 import { config as paddingLine } from './rules/padding-line-between-statements.js';
 import { config as preferConst } from './rules/prefer-const.js';
@@ -12,6 +13,7 @@ import { config as preferConst } from './rules/prefer-const.js';
 export const rules = [
   ...importSorting,
   ...noConsole,
+  ...noUnusedVars,
   ...paddingLine,
   ...getterReturn,
   ...preferConst,

--- a/configs/rules/no-unused-vars.js
+++ b/configs/rules/no-unused-vars.js
@@ -1,0 +1,19 @@
+/**
+ * @type {import('#types').PartialConfig[]}
+ */
+export const config = [
+  {
+    name: 'nvp:no-unused-vars',
+    rules: {
+      // Allows placeholder args and variables to still be defined for
+      // documentation or "for later" purposes
+      'no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+];

--- a/test-packages/node-js-cjs/common.cjs
+++ b/test-packages/node-js-cjs/common.cjs
@@ -4,4 +4,11 @@ module.exports = {
   foo() {
     return 2;
   },
+  
+  // Test no-unused-vars rule: underscore-prefixed should be allowed
+  testUnusedVars(_unusedParam, used) {
+    const _unusedVar = 'allowed';
+
+    return used || 'default';
+  },
 };

--- a/test-packages/node-js-cjs/index.js
+++ b/test-packages/node-js-cjs/index.js
@@ -4,4 +4,11 @@ module.exports = {
   foo() {
     return 2;
   },
+  
+  // Test no-unused-vars rule: underscore-prefixed should be allowed
+  testUnusedVars(_unusedParam, used) {
+    const _unusedVar = 'allowed';
+
+    return used || 'default';
+  },
 };

--- a/test-packages/node-js-mjs/index.js
+++ b/test-packages/node-js-mjs/index.js
@@ -1,3 +1,10 @@
 export function foo() {
   return 2;
 }
+
+// Test no-unused-vars rule: underscore-prefixed should be allowed
+export function testUnusedVars(_unusedParam, used) {
+  const _unusedVar = 'allowed';
+
+  return used || 'default';
+}

--- a/test-packages/node-ts-cjs/index.ts
+++ b/test-packages/node-ts-cjs/index.ts
@@ -4,4 +4,9 @@ module.exports = {
   foo(two: number) {
     return two;
   },
+  
+  // Test @typescript-eslint/no-unused-vars rule: underscore-prefixed params should be allowed
+  testUnusedVars(_unusedParam: string, used: string) {
+    return used || 'default';
+  },
 };

--- a/test-packages/node-ts-mjs/index.ts
+++ b/test-packages/node-ts-mjs/index.ts
@@ -5,3 +5,8 @@ export const _path = path;
 export function foo(two: number) {
   return two;
 }
+
+// Test @typescript-eslint/no-unused-vars rule: underscore-prefixed params should be allowed
+export function testUnusedVars(_unusedParam: string, used: string) {
+  return used || 'default';
+}


### PR DESCRIPTION
## Problem
JavaScript files don't allow underscore-prefixed unused variables while TypeScript files do, creating inconsistent behavior between file types.

## Solution
- Add `no-unused-vars` rule with `argsIgnorePattern: '^_'` and `varsIgnorePattern: '^_'` for JavaScript files
- Matches existing TypeScript behavior from `@typescript-eslint/no-unused-vars`

## Changes
- Created `configs/rules/no-unused-vars.js`
- Added to `configs/base.js`
- Added test coverage to existing test packages

Now `_unusedParam` and `_unusedVar` are allowed in both JS and TS files.