### PR TITLE
Missing rules in ember configs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,7 @@ export function forFiles(globs, override) {
 }
 
 export function combine(name, overrides) {
-  const configs = [overrides].flat();
+  const configs = [overrides].flat(Infinity);
 
   const files = new Set();
   const ignores = new Set();


### PR DESCRIPTION
👋

I found a lil bug which was causing lots of the nested `ember:overrides` rules to be thrown away. It's a tiny fix which just passes `flat(Infinity)` so that the `combine` function goes deeper than one level.

I love this config, thanks for making it available to everyone <3

I would very much appreciate it if you could cut a release for this 🙇